### PR TITLE
Switch to npm scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,14 @@ npm install
 This package is intended to help developers who are working on frontend components of Drupal core. It includes the following commands:
 
 ```
-gulp csslint
+npm test
 ```
 
 Lint all the CSS files in Drupal core, uses the rules defined in Drupal's .csslintrc.
 
 
 ```
-gulp watch
+npm start
 ```
 
 Livereload CSS files when working on core. Requires the [LiveReload Google Chrome Extension](https://chrome.google.com/webstore/detail/livereload/jnihajbhpnppcggbcgedagnkighmdlei?hl=en).
-

--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
     "type": "git",
     "url": "https://github.com/lewisnyman/drupalcore-frontend-toolkit"
   },
+  "scripts": {
+    "test": "./node_modules/.bin/gulp csslint",
+    "start": "./node_modules/.bin/gulp watch"
+  },
   "devDependencies": {
     "gulp": "^3.8.10",
     "gulp-csslint": "^0.1.5",


### PR DESCRIPTION
Currently, `gulp` is required to be installed globally in order to run `gulp csslint`. Using [npm scripts](https://docs.npmjs.com/misc/scripts), we can allow the user not not require installing Gulp globally. Simply running `npm test` will run the CSSLint tests through Gulp.
