### PR TITLE
Add an HTML Report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules/*
+npm-debug.log
+build

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,6 @@
 var gulp = require('gulp');
 var csslint = require('gulp-csslint');
+var htmlReporter = require('gulp-csslint-report');
 var livereload = require('gulp-livereload');
 
 // Config
@@ -22,4 +23,24 @@ gulp.task('reloadcss', function(vinyl) {
 });
 
 gulp.task('default', function () {
+});
+
+/**
+ * Build an HTML report.
+ */
+gulp.task('report', function() {
+  gulp.src(cssfiles)
+  .pipe(csslint('../.csslintrc'))
+  .pipe(htmlReporter({
+    filename: 'index.html',
+    directory: './build/'
+  }));
+});
+
+/**
+ * Deploy the built report to GitHub Pages.
+ */
+gulp.task('deploy', ['report'], function() {
+  return gulp.src('./build/**/*')
+  .pipe(deploy());
 });

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
   "devDependencies": {
     "gulp": "^3.8.10",
     "gulp-csslint": "^0.1.5",
+    "gulp-csslint-report": "git://github.com/RobLoach/gulp-csslint-report.git#fix-dependencies",
+    "gulp-gh-pages": "^0.4.0",
     "gulp-livereload": "^3.7.0",
     "gulp-newer": "^0.5.0"
   }


### PR DESCRIPTION
Running `gulp deploy` will shoot it out to https://lewisnyman.github.com/drupalcore-frontend-toolkit so that people don't need to run it locally in order to see the latest CSSLint report.

![csslintreport](https://cloud.githubusercontent.com/assets/25086/6084994/0de06bea-ae04-11e4-8dd2-7dff59173689.jpg)
