### PR TITLE
Implements visual regression testing with PhantomCSS

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,6 +7,8 @@ var gulpkss = require('gulp-kss');
 var gulpconcat = require('gulp-concat');
 var phantomcss = require('gulp-phantomcss');
 var argv = require('yargs').argv;
+var jsonfile = require('jsonfile');
+var clone = require('lodash.clone');
 
 // Config
 var cssfiles = ['../core/modules/**/*.css', '../core/themes/**/*.css', '/../core/misc/**/*.css'];
@@ -29,41 +31,44 @@ gulp.task('reloadcss', function(vinyl) {
 });
 
 gulp.task('phantomcss', function () {
-  var url,
-      page,
-      selector,
-      user,
-      password,
+  var config,
+      configfile,
       debug;
 
-  url = 'http://' + (typeof(argv.url) !== 'undefined' ? argv.url : 'drupal8.dev');
-  if (url.substr(-1) == '/') {
-    url = url.substr(0, url.length - 1);
+  configfile = typeof(argv.configfile) !== 'undefined' ? argv.configfile : false;
+  if (configfile) {
+    config = jsonfile.readFileSync(configfile);
+  } else {
+    config.tests = [{
+      'page': typeof argv.page !== 'undefined' ? argv.page : '/',
+      'selector': typeof argv.selector !== 'undefined' ? argv.selector : 'body'
+    }];
   }
 
-  page = typeof(argv.page) !== 'undefined' ? argv.page : '/';
-  if (page.substr(0, 1) !== '/') {
-    page = '/' + page;
+  config.url = 'http://' + (typeof argv.url !== 'undefined' ? argv.url : 'drupal8.dev');
+  if (config.url.substr(-1) == '/') {
+    config.url = config.url.substr(0, url.length - 1);
   }
 
-  selector = typeof(argv.selector) !== 'undefined' ? argv.selector : 'body';
-  user = typeof(argv.user) !== 'undefined' ? argv.user : 'admin';
-  password = typeof(argv.password) !== 'undefined' ? argv.password : 'admin';
+  config.user = typeof argv.user !== 'undefined' ? argv.user : 'admin';
+  config.password = typeof argv.password !== 'undefined' ? argv.password : 'admin';
+
   debug = typeof(argv.debug) !== 'undefined' ? 'debug' : 'error';
 
-  gulp.src('./phantomcss/testSinglePage.js')
-    .pipe(phantomcss({
-      screenshots: './phantomcss/references',
-      failures: './phantomcss/failures',
-      logLevel: debug,
-      drupalTestConfig: {
-        'url': url,
-        'page': page,
-        'selector': selector,
-        'user': user,
-        'password': password
-      }
-    }));
+  config.tests.forEach(function (test) {
+    var testConfig = clone(config);
+    delete testConfig.tests;
+    testConfig.page = test.page;
+    testConfig.selector = test.selector;
+
+    gulp.src('./phantomcss/testSinglePage.js')
+      .pipe(phantomcss({
+        screenshots: './phantomcss/references',
+        failures: './phantomcss/failures',
+        logLevel: debug,
+        drupalTestConfig: testConfig
+      }));
+  });
 });
 
 gulp.task('styleguide', function(vinyl) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,6 +5,8 @@ var livereload = require('gulp-livereload');
 var deploy = require('gulp-gh-pages');
 var gulpkss = require('gulp-kss');
 var gulpconcat = require('gulp-concat');
+var phantomcss = require('gulp-phantomcss');
+var argv = require('yargs').argv;
 
 // Config
 var cssfiles = ['../core/modules/**/*.css', '../core/themes/**/*.css', '/../core/misc/**/*.css'];
@@ -24,6 +26,44 @@ gulp.task('watch', function() {
 gulp.task('reloadcss', function(vinyl) {
   gulp.src(cssfiles)
     .pipe(livereload());
+});
+
+gulp.task('phantomcss', function () {
+  var url,
+      page,
+      selector,
+      user,
+      password,
+      debug;
+
+  url = 'http://' + (typeof(argv.url) !== 'undefined' ? argv.url : 'drupal8.dev');
+  if (url.substr(-1) == '/') {
+    url = url.substr(0, url.length - 1);
+  }
+
+  page = typeof(argv.page) !== 'undefined' ? argv.page : '/';
+  if (page.substr(0, 1) !== '/') {
+    page = '/' + page;
+  }
+
+  selector = typeof(argv.selector) !== 'undefined' ? argv.selector : 'body';
+  user = typeof(argv.user) !== 'undefined' ? argv.user : 'admin';
+  password = typeof(argv.password) !== 'undefined' ? argv.password : 'admin';
+  debug = typeof(argv.debug) !== 'undefined' ? 'debug' : 'error';
+
+  gulp.src('./phantomcss/testSinglePage.js')
+    .pipe(phantomcss({
+      screenshots: './phantomcss/references',
+      failures: './phantomcss/failures',
+      logLevel: debug,
+      drupalTestConfig: {
+        'url': url,
+        'page': page,
+        'selector': selector,
+        'user': user,
+        'password': password
+      }
+    }));
 });
 
 gulp.task('styleguide', function(vinyl) {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "gulp-livereload": "^3.7.0",
     "gulp-newer": "^0.5.0",
     "gulp-phantomcss": "0.0.4",
+    "jsonfile": "^2.2.1",
+    "lodash.clone": "^3.0.2",
     "slug": "^0.9.1",
     "yargs": "^3.7.2"
   }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "gulp-gh-pages": "^0.4.0",
     "gulp-kss": "0.0.2",
     "gulp-livereload": "^3.7.0",
-    "gulp-newer": "^0.5.0"
+    "gulp-newer": "^0.5.0",
+    "gulp-phantomcss": "0.0.4",
+    "slug": "^0.9.1",
+    "yargs": "^3.7.2"
   }
 }

--- a/phantomcss/testPage.js
+++ b/phantomcss/testPage.js
@@ -1,0 +1,96 @@
+var require = patchRequire(require);
+var slug = require('slug');
+var utils = require('utils');
+
+var testPage = function () {
+  this.casper = null;
+  this.config = {};
+  slug.charmap['/'] = '-';
+  slug.charmap['#'] = '-';
+};
+
+testPage.prototype.test = function (casper, phantomcss, config) {
+  var responseHandler = function (response) {
+    // This seems hacky, but casperjs is nasty and thats the only reliable way at the moment.
+    if (response.status == 403) {
+      this.casper.echo('Looks like we need to login...');
+      this.login();
+    } else if (response.status == 200 && response.url == this.config.url + this.config.page){
+      this.casper.then(this.takeScreenshot.bind(this));
+    }
+  }
+  this.casper = casper;
+  this.phantomcss = phantomcss;
+  this.config = config;
+  if (this.config.page.substr(0, 1) !== '/') {
+    this.config.page = '/' + this.config.page;
+  }
+
+  // We need to listen to the responses since thats the only reliable source to see if we are logged in.
+  casper.on('http.status.403', responseHandler.bind(this));
+  casper.on('http.status.200', responseHandler.bind(this));
+  this.casper.thenOpen(this.config.url + this.config.page);
+};
+
+testPage.prototype.login = function () {
+  var login = function () {
+    // Wait for the form to be rendered
+    casper
+      .waitForSelector("form#user-login-form input", fillForm.bind(this), true)
+      .then(function() {
+        // Check if we could log in.
+        if (this.exists('.messages.messages--error')) {
+          this.casper.die('Login failed, check login data');
+        } else {
+          console.log('Login successful.');
+        }
+      })
+      // Finally go the the page.
+      .thenOpen(this.config.url + this.config.page);
+  }
+  var fillForm = function () {
+    // Fill and submit the form
+    this.casper.fill('form#user-login-form', {
+      'name': this.config.user,
+      'pass': this.config.password
+    }, true);
+  }
+
+  this.casper
+    .thenOpen(this.config.url + '/user/login')
+    .then(login.bind(this));
+};
+
+testPage.prototype.takeScreenshot = function () {
+  var takeScreenshot = function () {
+    var title = this.config.page;
+
+    // Remove the first slash
+    if (title.substr(0, 1) === '/') {
+      title = title.substr(1);
+    }
+
+    // Use "frontpage" for <front>
+    if (title === '') {
+      title = 'frontpage';
+    }
+
+    // Make sure we have only valid filenames.
+    title = slug(title);
+
+    // If we do not screenshot the whole page, we add the selector to the title.
+    if (this.config.selector !== 'body') {
+      title = title + '--' + slug(this.config.selector);
+    }
+
+    // If we do not screenshot the whole page, we add the selector to the title.
+    if (typeof this.config.issue !== 'undefined') {
+      title = this.config.issue + '--' + title;
+    }
+
+    this.phantomcss.screenshot(this.config.selector, 0, '', 'screenshot--' + title);
+  };
+  casper.then(takeScreenshot.bind(this));
+};
+
+module.exports = new testPage();

--- a/phantomcss/testSinglePage.js
+++ b/phantomcss/testSinglePage.js
@@ -1,73 +1,7 @@
-var slug = require('slug'),
+var testPage = require('./testPage.js'),
     args = JSON.parse(casper.cli.args),
     config = args.drupalTestConfig;
 
-slug.charmap['/'] = '-';
-slug.charmap['#'] = '-';
-
-casper.start(config.url + config.page);
-
-casper
-  .then(function() {
-    var status = this.status(false);
-    if (status.currentHTTPStatus === 403) {
-      login();
-    } else {
-      takeScreenshot();
-    }
-  });
-
+casper.start(config.url);
+testPage.test(casper, phantomcss, config);
 casper.run();
-
-function login() {
-  casper
-    .thenOpen(config.url + '/user/login')
-    .then(function() {
-      // Wait for the form to be rendered
-      casper
-        .waitForSelector("form#user-login-form input", function() {
-          // Fill and submit the form
-          casper.fill('form#user-login-form', {
-            'name': config.user,
-            'pass': config.password
-          }, true);
-        }, true)
-        .then(function() {
-          // Check if we could log in.
-          if (this.exists('.messages.messages--error')) {
-            this.die('Login failed, check login data');
-          }
-        })
-        // Finally go the the page and take the screenshot.
-        .thenOpen(config.url + config.page)
-        .then(function() {
-          takeScreenshot();
-        });
-    })
-}
-
-function takeScreenshot() {
-  casper.then(function() {
-    var title = config.page;
-
-    // Remove the first slash
-    if (title.substr(0, 1) === '/') {
-      title = title.substr(1);
-    }
-
-    // Use "frontpage" for <front>
-    if (title === '') {
-      title = 'frontpage';
-    }
-
-    // Make sure we have only valid filenames.
-    title = slug(title);
-
-    // If we do not screenshot the whole page, we add the selector to the title.
-    if (config.selector !== 'body') {
-      title = title + '--' + slug(config.selector);
-    }
-
-    phantomcss.screenshot(config.selector, 0, '', 'screenshot--' + title);
-  })
-}

--- a/phantomcss/testSinglePage.js
+++ b/phantomcss/testSinglePage.js
@@ -1,0 +1,73 @@
+var slug = require('slug'),
+    args = JSON.parse(casper.cli.args),
+    config = args.drupalTestConfig;
+
+slug.charmap['/'] = '-';
+slug.charmap['#'] = '-';
+
+casper.start(config.url + config.page);
+
+casper
+  .then(function() {
+    var status = this.status(false);
+    if (status.currentHTTPStatus === 403) {
+      login();
+    } else {
+      takeScreenshot();
+    }
+  });
+
+casper.run();
+
+function login() {
+  casper
+    .thenOpen(config.url + '/user/login')
+    .then(function() {
+      // Wait for the form to be rendered
+      casper
+        .waitForSelector("form#user-login-form input", function() {
+          // Fill and submit the form
+          casper.fill('form#user-login-form', {
+            'name': config.user,
+            'pass': config.password
+          }, true);
+        }, true)
+        .then(function() {
+          // Check if we could log in.
+          if (this.exists('.messages.messages--error')) {
+            this.die('Login failed, check login data');
+          }
+        })
+        // Finally go the the page and take the screenshot.
+        .thenOpen(config.url + config.page)
+        .then(function() {
+          takeScreenshot();
+        });
+    })
+}
+
+function takeScreenshot() {
+  casper.then(function() {
+    var title = config.page;
+
+    // Remove the first slash
+    if (title.substr(0, 1) === '/') {
+      title = title.substr(1);
+    }
+
+    // Use "frontpage" for <front>
+    if (title === '') {
+      title = 'frontpage';
+    }
+
+    // Make sure we have only valid filenames.
+    title = slug(title);
+
+    // If we do not screenshot the whole page, we add the selector to the title.
+    if (config.selector !== 'body') {
+      title = title + '--' + slug(config.selector);
+    }
+
+    phantomcss.screenshot(config.selector, 0, '', 'screenshot--' + title);
+  })
+}


### PR DESCRIPTION
Run with:
gulp phantomcss

Parameters with defaults:
--url "drupal8.dev"
--config ""
--page "/"
--selector "body"
--user "admin"
--password "admin"
--debug (This one sets the log level to "debug")
## Usage for a single page:

``` bash
gulp phantomcss --selector ".node--view-mode-full > .node__content" --page "node/1" --url "d8.dev"
```
## Usage via configuration.json:

``` bash
gulp phantomcss --url "d8.dev" --configfile ../path/to/config.json
```
